### PR TITLE
Add financial section pages and sidebar links

### DIFF
--- a/src/app/cotizaciones/page.tsx
+++ b/src/app/cotizaciones/page.tsx
@@ -1,0 +1,3 @@
+export default function CotizacionesPage() {
+  return <h1>Cotizaciones</h1>;
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,3 @@
+export default function DashboardPage() {
+  return <h1>Dashboard</h1>;
+}

--- a/src/app/gastos/page.tsx
+++ b/src/app/gastos/page.tsx
@@ -1,0 +1,3 @@
+export default function GastosPage() {
+  return <h1>Gastos</h1>;
+}

--- a/src/app/ingresos/page.tsx
+++ b/src/app/ingresos/page.tsx
@@ -1,0 +1,3 @@
+export default function IngresosPage() {
+  return <h1>Ingresos</h1>;
+}

--- a/src/app/inversiones/page.tsx
+++ b/src/app/inversiones/page.tsx
@@ -1,0 +1,3 @@
+export default function InversionesPage() {
+  return <h1>Inversiones</h1>;
+}

--- a/src/app/prestamos/page.tsx
+++ b/src/app/prestamos/page.tsx
@@ -1,0 +1,3 @@
+export default function PrestamosPage() {
+  return <h1>Préstamos</h1>;
+}

--- a/src/app/resumen/page.tsx
+++ b/src/app/resumen/page.tsx
@@ -1,0 +1,3 @@
+export default function ResumenPage() {
+  return <h1>Resumen</h1>;
+}

--- a/src/app/ventas/page.tsx
+++ b/src/app/ventas/page.tsx
@@ -1,0 +1,3 @@
+export default function VentasPage() {
+  return <h1>Ventas</h1>;
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -10,6 +10,11 @@ const Sidebar = () => {
         <Link href="/tiendas" className="hover:text-blue-600">Tiendas</Link>
         <Link href="/ingresos" className="hover:text-blue-600">Ingresos</Link>
         <Link href="/resumen" className="hover:text-blue-600">Resumen</Link>
+        <Link href="/ventas" className="hover:text-blue-600">Ventas</Link>
+        <Link href="/cotizaciones" className="hover:text-blue-600">Cotizaciones</Link>
+        <Link href="/gastos" className="hover:text-blue-600">Gastos</Link>
+        <Link href="/prestamos" className="hover:text-blue-600">Préstamos</Link>
+        <Link href="/inversiones" className="hover:text-blue-600">Inversiones</Link>
       </nav>
     </aside>
   );


### PR DESCRIPTION
## Summary
- add placeholder pages for key financial sections
- update sidebar navigation links

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684911fef7b0832cb99e0caf93e4c1a8