### PR TITLE
Set up Jest with sample tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ pnpm dev
 bun dev
 ```
 
+## Running Tests
+
+Install dependencies and execute the test suite with:
+
+```bash
+npm install
+npm test
+```
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/.next/'],
+};
+
+export default config;

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/extend-expect';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "date-fns": "^4.1.0",
@@ -24,6 +25,12 @@
     "eslint-config-next": "14.2.29",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "@types/jest": "^29.5.11",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/src/app/(tiendas)/tiendas/__tests__/page.test.tsx
+++ b/src/app/(tiendas)/tiendas/__tests__/page.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import TiendasPage from '../page';
+import '@testing-library/jest-dom';
+
+describe('TiendasPage', () => {
+  it('renders Tiendas heading', () => {
+    render(<TiendasPage />);
+    expect(screen.getByText('Tiendas')).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import Header from '../Header';
+
+describe('Header', () => {
+  it('renders the title', () => {
+    render(<Header />);
+    expect(screen.getByText('Panel de Control')).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import Sidebar from '../Sidebar';
+import '@testing-library/jest-dom';
+
+describe('Sidebar', () => {
+  it('renders navigation links', () => {
+    render(<Sidebar />);
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Tiendas')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest using ts-jest
- add example unit tests for Header, Sidebar and Tiendas page
- document how to run the dev server and tests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684911fb2c70832cb0cbf42b97744c39