### PR TITLE
Add gastos component with chart and theme colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Features
+
+- Financial dashboard with pages for stores, incomes and expenses.
+- New **Gastos** module displays a vibrant chart of expenses by category and a detailed table.
+- Theme colors are driven by CSS variables so you can personalize the primary color.
+
 ## Getting Started
 
 First, run the development server:
@@ -26,6 +32,10 @@ npm test
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+
+### Customizing the primary color
+
+Modify the CSS variable `--primary` defined in `src/app/globals.css` to quickly change the accent color across the UI.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 

--- a/src/app/gastos/page.tsx
+++ b/src/app/gastos/page.tsx
@@ -1,3 +1,82 @@
+// src/app/gastos/page.tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import { Plus, Utensils, Car, Clapperboard, Bolt, Tag } from "lucide-react";
+import GastosChart, { GastoResumen } from "@/modules/gastos/GastosChart";
+
+interface Gasto {
+  id: number;
+  categoria: string;
+  descripcion: string;
+  monto: number;
+  fecha: string;
+}
+
+const icons: Record<string, JSX.Element> = {
+  Alimentación: <Utensils size={18} className="text-rose-500" />,
+  Transporte: <Car size={18} className="text-emerald-500" />,
+  Entretenimiento: <Clapperboard size={18} className="text-sky-500" />,
+  Servicios: <Bolt size={18} className="text-yellow-500" />,
+  Otros: <Tag size={18} className="text-violet-500" />,
+};
+
 export default function GastosPage() {
-  return <h1>Gastos</h1>;
+  const [gastos, setGastos] = useState<Gasto[]>([]);
+
+  useEffect(() => {
+    const ejemplo: Gasto[] = require("@/modules/gastos/data/gastos.json");
+    setGastos(ejemplo);
+  }, []);
+
+  const resumen: GastoResumen[] = gastos.reduce((acc: GastoResumen[], gasto) => {
+    const encontrado = acc.find((g) => g.categoria === gasto.categoria);
+    if (encontrado) {
+      encontrado.total += gasto.monto;
+    } else {
+      acc.push({ categoria: gasto.categoria, total: gasto.monto });
+    }
+    return acc;
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-2xl font-bold text-primary">Gastos</h2>
+        <button className="flex items-center gap-2 bg-primary hover:opacity-90 text-white px-4 py-2 rounded">
+          <Plus size={18} /> Nuevo gasto
+        </button>
+      </div>
+
+      <div className="bg-white shadow rounded p-4">
+        <h3 className="font-semibold mb-2">Distribución por categoría</h3>
+        <GastosChart data={resumen} />
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full table-auto border">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="px-4 py-2 text-left">Categoría</th>
+              <th className="px-4 py-2 text-left">Descripción</th>
+              <th className="px-4 py-2 text-left">Monto</th>
+              <th className="px-4 py-2 text-left">Fecha</th>
+            </tr>
+          </thead>
+          <tbody>
+            {gastos.map((g) => (
+              <tr key={g.id} className="border-t">
+                <td className="px-4 py-2 flex items-center gap-2">
+                  {icons[g.categoria]} {g.categoria}
+                </td>
+                <td className="px-4 py-2">{g.descripcion}</td>
+                <td className="px-4 py-2 text-right">${g.monto.toFixed(2)}</td>
+                <td className="px-4 py-2">{g.fecha}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,12 +5,14 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --primary: #3b82f6;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --primary: #60a5fa;
   }
 }
 

--- a/src/modules/gastos/GastosChart.tsx
+++ b/src/modules/gastos/GastosChart.tsx
@@ -1,0 +1,25 @@
+// src/modules/gastos/GastosChart.tsx
+"use client";
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
+
+export interface GastoResumen {
+  categoria: string;
+  total: number;
+}
+
+const COLORS = ["#ef4444", "#22c55e", "#3b82f6", "#eab308", "#a855f7"];
+
+export default function GastosChart({ data }: { data: GastoResumen[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={240}>
+      <PieChart>
+        <Pie dataKey="total" data={data} cx="50%" cy="50%" outerRadius={80} fill="#8884d8" label>
+          {data.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/modules/gastos/data/gastos.json
+++ b/src/modules/gastos/data/gastos.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": 1,
+    "categoria": "Alimentación",
+    "descripcion": "Supermercado",
+    "monto": 150.5,
+    "fecha": "2024-06-01"
+  },
+  {
+    "id": 2,
+    "categoria": "Transporte",
+    "descripcion": "Gasolina",
+    "monto": 75.0,
+    "fecha": "2024-06-03"
+  },
+  {
+    "id": 3,
+    "categoria": "Entretenimiento",
+    "descripcion": "Cine",
+    "monto": 40.25,
+    "fecha": "2024-06-05"
+  },
+  {
+    "id": 4,
+    "categoria": "Servicios",
+    "descripcion": "Electricidad",
+    "monto": 120.0,
+    "fecha": "2024-06-07"
+  },
+  {
+    "id": 5,
+    "categoria": "Otros",
+    "descripcion": "Regalo",
+    "monto": 30.0,
+    "fecha": "2024-06-10"
+  }
+]

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,6 +12,7 @@ const config: Config = {
       colors: {
         background: "var(--background)",
         foreground: "var(--foreground)",
+        primary: "var(--primary)",
       },
     },
   },


### PR DESCRIPTION
## Summary
- add vibrant gastos chart component
- create gastos page with icons and pie chart
- extend Tailwind theme with `primary` color
- expose `--primary` variable in globals for easy theming
- document features and theming instructions in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684917ec9434832c90406bbcb1954519